### PR TITLE
Fix local date handling for upcoming view and CSV import

### DIFF
--- a/index.html
+++ b/index.html
@@ -507,8 +507,9 @@
     function renderUpcoming(rows) {
       const tbody = $('#upcomingTable tbody'); tbody.innerHTML = "";
       const todayISO = toISO(new Date());
-      const endDate = toISO(new Date(new Date(todayISO).getTime() + 60*86400000));
-      const view = rows.filter(r => r.date >= todayISO && r.date <= endDate);
+      const todayMidnight = new Date(todayISO + 'T00:00:00');
+      const endISO = toISO(new Date(todayMidnight.getTime() + 60*86400000));
+      const view = rows.filter(r => r.date >= todayISO && r.date <= endISO);
       for (const r of view) {
         const tr = document.createElement('tr');
         tr.innerHTML = '<td>'+r.date+'</td>'
@@ -845,7 +846,9 @@
         for (let i=startIdx;i<rows.length;i++) {
           const r = rows[i]; if (!r || r.length===0) continue;
           const dateStr = (r[cDate]||'').trim(); if (!dateStr) continue;
-          const dt = new Date(dateStr);
+          const dt = /^\d{4}-\d{2}-\d{2}$/.test(dateStr)
+            ? new Date(dateStr + 'T00:00:00')
+            : new Date(dateStr);
           const iso = isNaN(dt) ? null : toISO(dt);
           if (!iso) continue;
           const amtN = parseNum(r[cAmt]);


### PR DESCRIPTION
## Summary
- anchor the 60-day upcoming window to a local-midnight date before extending it
- parse bare YYYY-MM-DD CSV dates as local midnights to avoid timezone-based drift

## Testing
- TZ=America/Los_Angeles node <<'NODE'
const toISO = (d) => new Date(d.getTime() - d.getTimezoneOffset()*60000).toISOString().slice(0,10);
const now = new Date('2025-01-15T12:34:56');
const todayISO = toISO(now);
const todayMidnight = new Date(todayISO + 'T00:00:00');
const endISO = toISO(new Date(todayMidnight.getTime() + 60*86400000));
const diffDays = (new Date(endISO + 'T00:00:00') - todayMidnight) / 86400000;
console.log({todayISO, todayMidnight: todayMidnight.toISOString(), endISO, diffDays});

const dateStr = '2025-01-01';
const oldISO = toISO(new Date(dateStr));
const newDate = /^\d{4}-\d{2}-\d{2}$/.test(dateStr) ? new Date(dateStr + 'T00:00:00') : new Date(dateStr);
const newISO = toISO(newDate);
console.log({oldISO, newISO});
NODE

------
https://chatgpt.com/codex/tasks/task_e_68cc19280ba8832ba157f6489507fa2f