### PR TITLE
Add light mode theme toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,37 +18,97 @@
       --card: #0b1220;
       --border: #1f2937;
       --shadow: rgba(0,0,0,0.35);
+      --glow1: rgba(96,165,250,0.08);
+      --glow2: rgba(167,139,250,0.08);
+      --tab-bg: #0b1220;
+      --tab-active-bg: linear-gradient(180deg, #121a2c, #0c1424);
+      --tab-active-border: #273244;
+      --tab-active-ring: rgba(96,165,250,0.25);
+      --input-bg: #0b1220;
+      --table-head: #0f172a;
+      --table-hover: rgba(96,165,250,0.06);
+      --primary-bg: linear-gradient(180deg, rgba(96,165,250,0.2), rgba(96,165,250,0.1));
+      --primary-border: rgba(96,165,250,0.35);
+      --header-bg: linear-gradient(180deg, rgba(11,18,32,0.9), rgba(11,18,32,0.6));
+      --chart-grid: rgba(255,255,255,0.08);
+      --chart-axis: rgba(255,255,255,0.6);
+    }
+    body.light {
+      --bg: #f8fafc;
+      --panel: #ffffff;
+      --muted: #64748b;
+      --text: #0f172a;
+      --accent: #2563eb;
+      --accent-2: #7c3aed;
+      --danger: #dc2626;
+      --ok: #16a34a;
+      --warn: #ca8a04;
+      --card: #ffffff;
+      --border: #d0d7e2;
+      --shadow: rgba(15,23,42,0.08);
+      --glow1: rgba(37,99,235,0.12);
+      --glow2: rgba(124,58,237,0.12);
+      --tab-bg: rgba(148,163,184,0.15);
+      --tab-active-bg: linear-gradient(180deg, #ffffff, #e2e8f0);
+      --tab-active-border: rgba(148,163,184,0.6);
+      --tab-active-ring: rgba(37,99,235,0.25);
+      --input-bg: #f1f5f9;
+      --table-head: #e2e8f0;
+      --table-hover: rgba(148,163,184,0.12);
+      --primary-bg: linear-gradient(180deg, rgba(37,99,235,0.12), rgba(37,99,235,0.08));
+      --primary-border: rgba(37,99,235,0.3);
+      --header-bg: linear-gradient(180deg, rgba(255,255,255,0.95), rgba(255,255,255,0.85));
+      --chart-grid: rgba(15,23,42,0.08);
+      --chart-axis: rgba(15,23,42,0.6);
     }
     * { box-sizing: border-box; }
     html, body { height: 100%; }
     body {
       margin: 0; font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans,
       Helvetica Neue, Arial, "Apple Color Emoji", "Segoe UI Emoji";
-      background: radial-gradient(1200px 800px at 10% 5%, rgba(96,165,250,0.08), transparent 60%),
-                  radial-gradient(1000px 600px at 90% 10%, rgba(167,139,250,0.08), transparent 60%),
+      background: radial-gradient(1200px 800px at 10% 5%, var(--glow1), transparent 60%),
+                  radial-gradient(1000px 600px at 90% 10%, var(--glow2), transparent 60%),
                   var(--bg);
       color: var(--text);
+      color-scheme: dark;
     }
+    body.light { color-scheme: light; }
     header {
       padding: 16px 20px;
       display: flex; align-items: center; gap: 16px; justify-content: space-between;
       border-bottom: 1px solid var(--border);
       backdrop-filter: blur(6px);
       position: sticky; top: 0; z-index: 10;
-      background: linear-gradient(180deg, rgba(11,18,32,0.9), rgba(11,18,32,0.6));
+      background: var(--header-bg);
+      flex-wrap: wrap;
     }
     .brand { display: flex; align-items: center; gap: 12px; }
     .logo { width: 28px; height: 28px; border-radius: 8px; background: linear-gradient(135deg, var(--accent), var(--accent-2)); box-shadow: 0 4px 20px var(--shadow); }
     h1 { font-size: 18px; margin: 0; letter-spacing: 0.3px; }
+    .header-actions { display: flex; align-items: center; gap: 12px; flex-wrap: wrap; }
     .tabs { display: flex; gap: 8px; flex-wrap: wrap; }
     .tab-btn {
-      background: #0b1220;
+      background: var(--tab-bg);
       border: 1px solid var(--border);
       color: var(--text);
       padding: 8px 12px; border-radius: 10px;
       cursor: pointer; transition: all 0.15s ease;
     }
-    .tab-btn.active { background: linear-gradient(180deg, #121a2c, #0c1424); border-color: #273244; box-shadow: inset 0 0 0 1px rgba(96,165,250,0.25); }
+    .tab-btn.active { background: var(--tab-active-bg); border-color: var(--tab-active-border); box-shadow: inset 0 0 0 1px var(--tab-active-ring); }
+    .theme-toggle {
+      background: var(--tab-bg);
+      border: 1px solid var(--border);
+      color: var(--text);
+      border-radius: 999px;
+      padding: 6px 12px;
+      cursor: pointer;
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      transition: box-shadow 0.2s ease, background 0.2s ease;
+    }
+    .theme-toggle:hover { box-shadow: 0 6px 20px var(--shadow); }
+    .theme-toggle:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
     main { padding: 20px; max-width: 1200px; margin: 0 auto; }
     section.tab { display: none; }
     section.tab.active { display: block; }
@@ -73,15 +133,15 @@
     .row { display: flex; gap: 10px; align-items: center; flex-wrap: wrap; }
     label.small { font-size: 12px; color: var(--muted); }
     input, select, textarea {
-      background: #0b1220; color: var(--text);
+      background: var(--input-bg); color: var(--text);
       border: 1px solid var(--border); border-radius: 10px;
       padding: 8px 10px; outline: none;
     }
     input[type="date"] { padding: 6px 10px; }
     input[type="number"] { width: 140px; }
     button.primary {
-      background: linear-gradient(180deg, rgba(96,165,250,0.2), rgba(96,165,250,0.1));
-      border: 1px solid rgba(96,165,250,0.35);
+      background: var(--primary-bg);
+      border: 1px solid var(--primary-border);
       color: var(--text); border-radius: 10px; padding: 8px 12px; cursor: pointer;
     }
     button.ghost {
@@ -94,8 +154,8 @@
       width: 100%; border-collapse: collapse; font-size: 14px; overflow: hidden; border-radius: 10px;
     }
     th, td { border-bottom: 1px solid var(--border); padding: 8px 10px; text-align: left; }
-    thead th { background: #0f172a; position: sticky; top: 0; z-index: 1; }
-    tbody tr:hover { background: rgba(96,165,250,0.06); }
+    thead th { background: var(--table-head); position: sticky; top: 0; z-index: 1; }
+    tbody tr:hover { background: var(--table-hover); }
     .right { text-align: right; }
 
     .chart-wrap { height: 300px; width: 100%; }
@@ -121,10 +181,13 @@
         <div class="sub">Local-only • Single-file • Offline ready</div>
       </div>
     </div>
-    <div class="tabs">
-      <button class="tab-btn active" data-tab="dashboard">Dashboard</button>
-      <button class="tab-btn" data-tab="expenses">Expenses / One-offs</button>
-      <button class="tab-btn" data-tab="income">Income</button>
+    <div class="header-actions">
+      <div class="tabs">
+        <button class="tab-btn active" data-tab="dashboard">Dashboard</button>
+        <button class="tab-btn" data-tab="expenses">Expenses / One-offs</button>
+        <button class="tab-btn" data-tab="income">Income</button>
+      </div>
+      <button class="theme-toggle" id="toggleTheme" type="button" aria-pressed="false">☀️ Light mode</button>
     </div>
   </header>
 
@@ -310,6 +373,30 @@
     // --- Utilities ---
     const $ = (sel) => document.querySelector(sel);
     const $$ = (sel) => Array.from(document.querySelectorAll(sel));
+    const THEME_KEY = 'cashflow_theme_v1';
+    const themeToggleBtn = document.getElementById('toggleTheme');
+    const prefersLight = window.matchMedia && window.matchMedia('(prefers-color-scheme: light)').matches;
+    let currentTheme = localStorage.getItem(THEME_KEY);
+    if (currentTheme !== 'light' && currentTheme !== 'dark') {
+      currentTheme = prefersLight ? 'light' : 'dark';
+    }
+    function applyTheme(theme) {
+      const isLight = theme === 'light';
+      document.body.classList.toggle('light', isLight);
+      if (themeToggleBtn) {
+        themeToggleBtn.setAttribute('aria-pressed', isLight ? 'true' : 'false');
+        themeToggleBtn.textContent = isLight ? '🌙 Dark mode' : '☀️ Light mode';
+      }
+    }
+    applyTheme(currentTheme);
+    if (themeToggleBtn) {
+      themeToggleBtn.addEventListener('click', () => {
+        currentTheme = document.body.classList.contains('light') ? 'dark' : 'light';
+        applyTheme(currentTheme);
+        localStorage.setItem(THEME_KEY, currentTheme);
+        renderChart(computeDaily());
+      });
+    }
     const fmt = (n) => { if (isNaN(n)) return "$0"; const s = n.toLocaleString(undefined, {minimumFractionDigits:2, maximumFractionDigits:2}); return (n < 0 ? "-$" + Math.abs(n).toLocaleString(undefined, {minimumFractionDigits:2, maximumFractionDigits:2}) : "$" + s); };
     const parseNum = (v) => { const n = parseFloat(v); return isNaN(n) ? 0 : n; };
     const toISO = (d) => new Date(d.getTime() - d.getTimezoneOffset()*60000).toISOString().slice(0,10);
@@ -527,6 +614,12 @@
       svg.innerHTML = "";
       if (!rows.length) return;
 
+      const style = getComputedStyle(document.body);
+      const gridColor = (style.getPropertyValue('--chart-grid') || '').trim() || 'rgba(255,255,255,0.08)';
+      const axisColor = (style.getPropertyValue('--chart-axis') || '').trim() || 'rgba(255,255,255,0.6)';
+      const accent1 = (style.getPropertyValue('--accent') || '').trim() || '#60a5fa';
+      const accent2 = (style.getPropertyValue('--accent-2') || '').trim() || '#a78bfa';
+
       const xs = rows.map((_,i)=> i);
       const ys = rows.map(r=> r.balance);
 
@@ -541,10 +634,10 @@
 
       // grid lines & axes
       const grid = document.createElementNS("http://www.w3.org/2000/svg", "g");
-      grid.setAttribute("stroke", "rgba(255,255,255,0.08)");
+      grid.setAttribute("stroke", gridColor);
       grid.setAttribute("stroke-width", "1");
       const axis = document.createElementNS("http://www.w3.org/2000/svg", "g");
-      axis.setAttribute("fill", "rgba(255,255,255,0.6)");
+      axis.setAttribute("fill", axisColor);
       axis.setAttribute("font-size", "10");
 
       const steps = 4;
@@ -581,8 +674,8 @@
       const grad = document.createElementNS("http://www.w3.org/2000/svg", "linearGradient");
       grad.setAttribute("id", "grad1");
       grad.setAttribute("x1", "0"); grad.setAttribute("x2", "1"); grad.setAttribute("y1", "0"); grad.setAttribute("y2", "0");
-      const stop1 = document.createElementNS("http://www.w3.org/2000/svg", "stop"); stop1.setAttribute("offset", "0%"); stop1.setAttribute("stop-color", "#60a5fa");
-      const stop2 = document.createElementNS("http://www.w3.org/2000/svg", "stop"); stop2.setAttribute("offset", "100%"); stop2.setAttribute("stop-color", "#a78bfa");
+      const stop1 = document.createElementNS("http://www.w3.org/2000/svg", "stop"); stop1.setAttribute("offset", "0%"); stop1.setAttribute("stop-color", accent1);
+      const stop2 = document.createElementNS("http://www.w3.org/2000/svg", "stop"); stop2.setAttribute("offset", "100%"); stop2.setAttribute("stop-color", accent2);
       grad.appendChild(stop1); grad.appendChild(stop2);
       defs.appendChild(grad);
       svg.appendChild(defs);


### PR DESCRIPTION
## Summary
- add a theme toggle to switch between dark and light appearances
- define shared CSS variables for both themes and restyle UI elements to inherit them
- persist the selected theme and update the balance chart colors based on CSS variables

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cc198b309c832b8d69e25c167d77b9