### PR TITLE
Set up Express server with EJS view

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "artec-cashflow-tracker",
+  "version": "1.0.0",
+  "description": "Cash flow forecasting dashboard served via Express and EJS.",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "keywords": [
+    "cashflow",
+    "forecast",
+    "express"
+  ],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "ejs": "^3.1.9",
+    "express": "^4.19.2"
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,24 @@
+const path = require('path');
+const express = require('express');
+
+const app = express();
+const PORT = process.env.PORT || 3000;
+
+app.set('view engine', 'ejs');
+app.set('views', path.join(__dirname, 'views'));
+
+app.use(express.static(path.join(__dirname, 'public')));
+
+app.get('/', (req, res) => {
+  res.render('index', {
+    pageTitle: 'Cash Flow Forecaster — 2025',
+    forecastYear: '2025',
+    bodyClass: '',
+    headContent: '',
+    bodyScripts: ''
+  });
+});
+
+app.listen(PORT, () => {
+  console.log(`Server running on http://localhost:${PORT}`);
+});

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -3,7 +3,8 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-  <title>Cash Flow Forecaster — 2025</title>
+  <title><%- pageTitle %></title>
+  <%- headContent || '' %>
   <style>
     :root {
       --bg: #0f172a;
@@ -172,12 +173,12 @@
     .footer { color: var(--muted); font-size: 12px; text-align:center; padding: 12px; }
   </style>
 </head>
-<body>
+<body class="<%- bodyClass || '' %>">
   <header>
     <div class="brand">
       <div class="logo"></div>
       <div>
-        <h1>Cash Flow Forecaster — 2025</h1>
+        <h1>Cash Flow Forecaster — <%- forecastYear %></h1>
         <div class="sub">Local-only • Single-file • Offline ready</div>
       </div>
     </div>
@@ -1102,5 +1103,6 @@
 
     renderAll();
   </script>
+  <%- bodyScripts || '' %>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- initialize an Express server entry point that renders the dashboard through an EJS template and serves static assets
- convert the existing HTML dashboard into `views/index.ejs` with template placeholders for future dynamic data
- add Node project metadata, scripts, and ignore rules for the new server structure

## Testing
- node server.js *(fails: missing local express dependency because npm install was blocked by registry access)*

------
https://chatgpt.com/codex/tasks/task_e_68cc26d0e030832b9f61a3d7ca7e4d93